### PR TITLE
Solr Init - set upper case to WINDOWSSERVERCORE_VERSION

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -19,7 +19,7 @@ services:
       context:
         .\docker\images\windows\demo-solr-init
       args:
-        BASE_IMAGE: ${SITECORE_DOCKER_REGISTRY}sxp/sitecore-xp0-solr-init:${SITECORE_VERSION}-${windowsservercore_version}
+        BASE_IMAGE: ${SITECORE_DOCKER_REGISTRY}sxp/sitecore-xp0-solr-init:${SITECORE_VERSION}-${WINDOWSSERVERCORE_VERSION}
         SXA_ASSETS: ${SITECORE_DOCKER_REGISTRY}sxp/modules/sitecore-sxa-xp1-assets:${SITECORE_VERSION}-${SITECORE_ASSET_NANOSERVER_VERSION}
 
   xdbsearchworker:


### PR DESCRIPTION
Fix for "Error response from daemon: manifest for scr.sitecore.com/sxp/sitecore-xp0-solr-init:10.2- not found: manifest unknown: manifest tagged by "10.2-" is not found"