### PR TITLE
Prevent `Unrecognised volume spec: file '\\.\pipe\docker_engine'` error from Docker.

### DIFF
--- a/docker-compose-xp1.yml
+++ b/docker-compose-xp1.yml
@@ -16,8 +16,8 @@ services:
     healthcheck:
       test: ["CMD", "traefik", "healthcheck", "--ping"]
     volumes:
-      - source: \\.\pipe\docker_engine
-        target: \\.\pipe\docker_engine
+      - source: \\.\pipe\docker_engine\
+        target: \\.\pipe\docker_engine\
         type: npipe
       - ./traefik:C:/etc/traefik
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
     healthcheck:
       test: ["CMD", "traefik", "healthcheck", "--ping"]
     volumes:
-      - source: \\.\pipe\docker_engine
-        target: \\.\pipe\docker_engine
+      - source: \\.\pipe\docker_engine\
+        target: \\.\pipe\docker_engine\
         type: npipe
       - ./traefik:C:/etc/traefik
     depends_on:


### PR DESCRIPTION
Docker Compose threw an `Unrecognised volume spec: file '\\.\pipe\docker_engine'` error while getting the environment up.
Adding the trailing slash to the volume paths solved this.